### PR TITLE
Fix extra Target configurations are generated when Project has custom configurations

### DIFF
--- a/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -101,7 +101,7 @@ public final class ModuleMapMapper: WorkspaceMapping {
                     mappedSettingsDictionary[Self.otherCFlagsSetting] = updatedOtherCFlags
                 }
 
-                mappedTarget.settings = (mappedTarget.settings ?? .default).with(base: mappedSettingsDictionary)
+                mappedTarget.settings = (mappedTarget.settings ?? mappedProject.settings).with(base: mappedSettingsDictionary)
                 mappedProject.targets[targetIndex] = mappedTarget
             }
             mappedWorkspace.projects[projectIndex] = mappedProject


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4804

### Short description 📝

This Pull Request fixes the problem of generating extra configurations for the target. This case occurs when the `Target` does not have `settings` specified in the manifest, the `Project` has custom `settings` with custom configurations and there are module maps to be linked to a given target.

### How to test the changes locally 🧐

All existing tests pass. This case can be tested on an [example project](https://github.com/francuim-d/TuistConfigurationsSample). Here custom configurations are specified only for Project. When `.external(name: "FirebaseCrashlytics")` dependency added to Target extra settings are generated.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [x] In case the PR introduces changes that affect users, the documentation has been updated
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
